### PR TITLE
fixed box-sizing assumptions

### DIFF
--- a/source/stable/jquery.layout.js
+++ b/source/stable/jquery.layout.js
@@ -467,7 +467,7 @@ $.layout = {
 		if (outerWidth <= 0) return 0;
 
 		var lb	= $.layout.browser
-		,	bs	= !lb.boxModel ? "border-box" : lb.boxSizing ? $E.css("boxSizing") : "content-box"
+		,	bs	= $E.css("boxSizing") || "content-box"
 		,	b	= $.layout.borderWidth
 		,	n	= $.layout.cssNum
 		,	W	= outerWidth
@@ -493,7 +493,7 @@ $.layout = {
 		if (outerHeight <= 0) return 0;
 
 		var lb	= $.layout.browser
-		,	bs	= !lb.boxModel ? "border-box" : lb.boxSizing ? $E.css("boxSizing") : "content-box"
+		,	bs	= $E.css("boxSizing") || "content-box"
 		,	b	= $.layout.borderWidth
 		,	n	= $.layout.cssNum
 		,	H	= outerHeight


### PR DESCRIPTION
The default box-sizing is content-box, not border-box. This causes a layout issue in IE 10 and probably others when no box-sizing is set and $.browser.boxModel is not available. Honestly, there is no reason to even make all those browser version checks anyway. Just fetch the boxSizing value and if its not available or not set, default to content-box.

See: https://developer.mozilla.org/en-US/docs/Web/CSS/box-sizing
